### PR TITLE
Round lehumra times to the strict minute instead of shifting a full minute

### DIFF
--- a/zmanim_bot/integrations/zmanim_models.py
+++ b/zmanim_bot/integrations/zmanim_models.py
@@ -29,8 +29,14 @@ LEHUMRA_TO_MAX = True
 
 
 def round_time_lehumra(dt: datetime, lehumra_to_max: bool) -> datetime:
-    delta = timedelta(minutes=1 if lehumra_to_max else -1)
-    return dt + delta
+    # Round to the whole minute in the strict direction: deadlines floor,
+    # onsets ceil. The old ±1 minute shift over-corrected — displayed times
+    # are truncated to minutes, so flooring already errs on the safe side,
+    # and the extra minute made deadlines a full minute earlier than needed.
+    rounded = dt.replace(second=0, microsecond=0)
+    if lehumra_to_max and rounded != dt:
+        rounded += timedelta(minutes=1)
+    return rounded
 
 
 class BaseModelWithZmanimLehumra(BaseModel):


### PR DESCRIPTION
## What

`round_time_lehumra` shifted every time by a whole minute (+1 for onsets, −1 for deadlines) on top of the minute truncation applied at display time (`isoformat(timespec='minutes')`). For deadlines that double-corrected: sunset 19:45:50 displayed as **19:44**, a full minute earlier than needed. For onsets, a time already on an exact minute gained a spurious extra minute.

Now the function rounds to the whole minute in the strict direction instead:

- **deadlines floor** — 19:45:50 → 19:45 (still safe: 19:45:00 precedes the exact time);
- **onsets ceil** — 5:39:20 → 5:40, and an already-exact minute stays put.

The per-field direction logic (`LEHUMRA_MINUS_MINUTE_NAMES`, the candle-lighting weekday / second-day branches) is unchanged.

This matches the new lehumra mode in `zmanim_site` (benyaming/zmanim_site#54), so both products display identical rounded times.

## Testing
No test suite in the repo — verified through the real pydantic models with the repo venv: onset/deadline zmanim, candle lighting on a regular Friday (floor), second night on Motzei Shabbat (ceil), second day on a Friday (floor), fast start (floor) and fast end (ceil), plus exact-minute and null-second edge cases. All assertions passed.