### PR TITLE
Give English mini-app URLs an explicit /en prefix

### DIFF
--- a/zmanim_bot/miniapp/urls.py
+++ b/zmanim_bot/miniapp/urls.py
@@ -4,8 +4,11 @@ from zmanim_bot.config import config
 from zmanim_bot.exceptions import NoLocationException
 from zmanim_bot.repository.models import User
 
-# The site serves English at the root and prefixes the other locales.
-_LOCALE_PATHS = {'he': '/he', 'ru': '/ru'}
+# English must be an explicit /en too, even though the site serves it at the
+# root: a bare root URL goes through the site's locale detection, and the
+# webview's Accept-Language (the phone language) would override the bot
+# language. /en redirects to / while pinning the locale cookie.
+_LOCALE_PATHS = {'en': '/en', 'he': '/he', 'ru': '/ru'}
 
 
 def build_miniapp_url(user: User) -> str | None:


### PR DESCRIPTION
Launching the mini app with an **English** bot language opened the app in the phone's language instead (e.g. Russian): English is the site's default locale, so `build_miniapp_url` emitted the bare root URL — and the site's next-intl middleware then ran locale detection on `/`, where the webview's `Accept-Language` header won and 307-redirected to `/ru`.

Verified against the site's middleware:

- `GET /?lat=…` with `Accept-Language: ru` → `307 /ru?lat=…` (the bug)
- `GET /en?lat=…` with `Accept-Language: ru` → `307 /?lat=…` **+ `Set-Cookie: NEXT_LOCALE=en`**, after which `/` serves English (the fix — the explicit prefix pins the cookie, which beats the header; query params and the `#tgWebApp…` fragment survive the redirect)

So English now gets an explicit `/en` like `/he` and `/ru` already had. A user with no bot language set still gets the bare root, deliberately — the site's own detection is the best guess there.
