### PR TITLE
Normalize the mini-app API path against a stripped webhook prefix

### DIFF
--- a/zmanim_bot/main.py
+++ b/zmanim_bot/main.py
@@ -14,7 +14,10 @@ from zmanim_bot.utils import ensure_mongo_index
 
 sentry_sdk.init(dsn=config.SENTRY_KEY, integrations=[AioHttpIntegration()])
 
-MINIAPP_API_PATH = f'{config.WEBHOOK_PATH}/miniapp'
+# Normalized against a trailing slash: a reverse proxy that strips the public
+# prefix leaves WEBHOOK_PATH as '/', and the naive f-string would register
+# '//miniapp' — unreachable from outside, since nginx merges double slashes.
+MINIAPP_API_PATH = f"{config.WEBHOOK_PATH.rstrip('/')}/miniapp"
 
 # Keeps the polling-mode API server alive for the process lifetime.
 _dev_api_runner: web.AppRunner | None = None


### PR DESCRIPTION
In prod the mini-app API 404s on every route while the webhook works fine. Diagnosis from outside: the 404s are aiohttp's (nginx forwards the subpaths into the container), and the webhook working means the internal path for the public `/zmanim_bot` equals `WEBHOOK_PATH` — so behind a prefix-stripping proxy (`location /zmanim_bot/ { proxy_pass http://…/; }`, confirmed by the auto-301 on the unslashed path) the container runs with `WEBHOOK_PATH=/`.

With that, `MINIAPP_API_PATH = f'{WEBHOOK_PATH}/miniapp'` registered the routes at `//miniapp` — which is unreachable from outside no matter what, because nginx merges consecutive slashes in request URIs.

Fix: `rstrip('/')` before appending, so:

| internal `WEBHOOK_PATH` | routes registered at | matches external `…/zmanim_bot/miniapp/*` |
| --- | --- | --- |
| `/zmanim_bot` (URI-preserving proxy) | `/zmanim_bot/miniapp` | yes (unchanged) |
| `/` or `` (prefix-stripping proxy) | `/miniapp` | yes (fixed) |

No public URL change: `NEXT_PUBLIC_TG_BOT_API_URL` stays `https://tg.ginzburg.io/zmanim_bot/miniapp`.

After deploy, `curl -X POST https://tg.ginzburg.io/zmanim_bot/miniapp/me -H 'Content-Type: application/json' -d '{"init_data":"x"}'` should return 401 instead of 404.
